### PR TITLE
setdefault无论字典中是否有这个key值，都会调用后面的 self.remote_address导致出错，所以提前判断

### DIFF
--- a/weixin/pay.py
+++ b/weixin/pay.py
@@ -133,7 +133,7 @@ class WeixinPay(object):
         if data["trade_type"] == "NATIVE" and "product_id" not in data:
             raise WeixinPayError("trade_type为NATIVE时，product_id为必填参数")
         data.setdefault("notify_url", self.notify_url)
-        if "spbill_create_id" not in data:
+        if "spbill_create_ip" not in data:
             data.setdefault("spbill_create_ip", self.remote_addr)
 
         raw = self._fetch(url, data)

--- a/weixin/pay.py
+++ b/weixin/pay.py
@@ -133,7 +133,8 @@ class WeixinPay(object):
         if data["trade_type"] == "NATIVE" and "product_id" not in data:
             raise WeixinPayError("trade_type为NATIVE时，product_id为必填参数")
         data.setdefault("notify_url", self.notify_url)
-        data.setdefault("spbill_create_ip", self.remote_addr)
+        if "spbill_create_id" not in data:
+            data.setdefault("spbill_create_ip", self.remote_addr)
 
         raw = self._fetch(url, data)
         return raw


### PR DESCRIPTION
File "payment/payment_util.py", line 58, in get_wechat_order
    attach="other info", spbill_create_ip="127.0.0.1")
  File "/usr/local/lib/python3.5/dist-packages/weixin/pay.py", line 138, in unified_order
    data.setdefault("spbill_create_ip", self.remote_addr)
  File "/usr/local/lib/python3.5/dist-packages/weixin/pay.py", line 54, in remote_addr
    return request.remote_addr
  File "/usr/local/lib/python3.5/dist-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/usr/local/lib/python3.5/dist-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "/usr/local/lib/python3.5/dist-packages/flask/globals.py", line 37, in _lookup_req_object
    raise RuntimeError(_request_ctx_err_msg)
RuntimeError: Working outside of request context.