### PR TITLE
签名appid改为可选参数

### DIFF
--- a/weixin/pay.py
+++ b/weixin/pay.py
@@ -81,8 +81,9 @@ class WeixinPay(object):
             raw[child.tag] = child.text
         return raw
 
-    def _fetch(self, url, data, use_cert=False):
-        data.setdefault("appid", self.app_id)
+    def _fetch(self, url, data, use_cert=False, appid=True):
+        if appid:
+            data.setdefault("appid", self.app_id)
         data.setdefault("mch_id", self.mch_id)
         data.setdefault("nonce_str", self.nonce_str)
         data.setdefault("sign", self.sign(data))
@@ -262,7 +263,7 @@ class WeixinPay(object):
             raise WeixinPayError("企业付款接口中，缺少必填参数bank_code")
         if "amount" not in data:
             raise WeixinPayError("企业付款接口中，缺少必填参数amount")
-        return self._fetch(url, data, True)
+        return self._fetch(url, data, True, False)
 
     def pay_individual_bank_query(self, **data):
         """企业付款到银行卡查询"""
@@ -271,7 +272,7 @@ class WeixinPay(object):
             raise WeixinPayError("企业接口需要双向证书'")
         if "partner_trade_no" not in data:
             raise WeixinPayError("企业付款接口中, 缺少必要的参数partner_trade_no")
-        return self._fetch(url, data, True)
+        return self._fetch(url, data, True, False)
 
     def pay_individual_query(self, **data):
         """企业付款到零钱查询"""


### PR DESCRIPTION
企业付款到银行卡和付款到银行卡查询时，如果签名参数里包含`appid`，会报`SIGNERROR`

可参考文档: https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=24_2