### PR TITLE
improving set_cookie security

### DIFF
--- a/example/login.py
+++ b/example/login.py
@@ -35,5 +35,5 @@ def authorized():
     openid = data.openid
     resp = redirect(next)
     expires = datetime.now() + timedelta(days=1)
-    resp.set_cookie("openid", openid, expires=expires)
+    resp.set_cookie("openid", openid, expires=expires, secure=True, httponly=True, samesite='Lax')
     return resp


### PR DESCRIPTION
Hi zwc,

We have a free program analysis tool for Python web projects, called Bento. While we were scanning GitHub projects for issues, it triggered a warning for the set_cookie method on your app.

You may want to set the `secure`, `httponly` and `samesite` parameters for `set_cookie()` function in your example login code, according to Flask best practices (https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options). This will make the code more resilient against XSS attacks (https://techblog.topdesk.com/security/cookie-security/).

Note that Bento found some unsafe use of XMLParser usage (msg.py:62) but I haven't touched that to keep this PR simple. If you are interested, feel free to download Bento from https://bento.dev and take a look at them.